### PR TITLE
fix: make parameter parsing architecture-independent

### DIFF
--- a/src/linux/main_linux.c
+++ b/src/linux/main_linux.c
@@ -465,7 +465,7 @@ int main(int argc, char **argv) {
     plimit_frames = 0;
 
     while (!done) {
-        char c;
+        signed char c;
 
         switch (c = getopt(argc, argv, opts)) {
         case EOF:


### PR DESCRIPTION
as described on mm